### PR TITLE
Simulation & autonomous path updates

### DIFF
--- a/src/main/java/org/frcteam2910/mk3/Robot.java
+++ b/src/main/java/org/frcteam2910/mk3/Robot.java
@@ -32,9 +32,9 @@ public class Robot extends TimedRobot {
     public SimplePathBuilder builder;
     @Override
     public void autonomousInit() {
-//        SimplePathBuilder builder = new SimplePathBuilder(new Vector2(0, 0), Rotation2.fromDegrees(0));
-//        robotContainer.drivetrainSubsystem.follow(builder.lineTo(new Vector2(10000, 0)).build());
-//        robotContainer.drivetrainSubsystem.resetPose(RigidTransform2.ZERO);
+        robotContainer.drivetrainSubsystem.resetPose(RigidTransform2.ZERO);
+        SimplePathBuilder builder = new SimplePathBuilder(new Vector2(0, 0), Rotation2.fromDegrees(0));
+        robotContainer.drivetrainSubsystem.follow(builder.lineTo(new Vector2(20, 0)).build());
     }
 
     @Override


### PR DESCRIPTION
Update the drivetrain trajectory follower to use a reasonable default of
12 inches for distance sampling.
Update the auto path to a reasonable default of 20 inches
Update the drivetrain to use WPI_TalonFX so the motors can be simulated
Add a "perfect world" physics model of the drive motors where the
position is linearly dependent on output voltage